### PR TITLE
Add singleLine prop to prevent line breaks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minidoc-editor",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "./dist/minidoc.min.js",
   "types": "./dist/types",
   "files": [

--- a/public/demo.css
+++ b/public/demo.css
@@ -161,3 +161,21 @@ main {
   border-radius: 0.25rem;
   text-decoration: none;
 }
+
+.title-editor {
+  padding: 0.75rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 2.25rem;
+}
+
+.title-editor p {
+  margin: 0;
+}
+
+.title-editor:focus {
+  border: solid 1px blue;
+}
+
+.title-editor.minidoc-editor::before {
+  padding: 24px 8px;
+}

--- a/public/demo.ts
+++ b/public/demo.ts
@@ -57,8 +57,19 @@ const editor = minidoc({
   ],
 });
 
+const titleEl = document.querySelector('.title-doc');
+titleEl.remove();
+
+const titleEditor = minidoc({
+  readonly,
+  doc: titleEl.innerHTML,
+  middleware: [placeholder('Title here')],
+  singleLine: true,
+});
+titleEditor.root.classList.add('title-editor');
+
 Dom.appendChildren(
-  [!readonly && Sticky(editor.toolbar.root), editor.root],
+  [!readonly && Sticky(editor.toolbar.root), titleEditor.root, editor.root],
   document.querySelector('main'),
 );
 

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <main></main>
+  <div class="title-doc" style="display: none;"><p>This is title!</p></div>
   <div class="example-doc" style="display: none">
     <h1>This is editable.</h1>
     <p>The video below should <strong>not</strong> flicker when you undo / redo after typing.</p>

--- a/src/minidoc/minidoc.ts
+++ b/src/minidoc/minidoc.ts
@@ -74,7 +74,7 @@ export function minidoc<T extends Array<EditorMiddleware>>(
   root.innerHTML = opts.doc;
   // If the root already has an editor associated with it, dispose it.
   (root as any).$editor?.dispose();
-  const core: MinidocBase = { root, readonly: opts.readonly };
+  const core: MinidocBase = { root, readonly: opts.readonly, singleLine: opts.singleLine };
   const middleware = opts.middleware
     ? [...defaultMiddleware, ...opts.middleware]
     : defaultMiddleware;

--- a/src/style-prevention/style-prevention.ts
+++ b/src/style-prevention/style-prevention.ts
@@ -87,12 +87,18 @@ function onInput(e: KeyboardEvent) {
   }
 }
 
-function onEnter(e: KeyboardEvent) {
+function onEnter(e: KeyboardEvent, editor: MinidocBase) {
   const range = Rng.currentRange();
   if (!range) {
     return;
   }
   e.preventDefault();
+
+  // Returning here to prevent line breaks.
+  if (editor.singleLine) {
+    return;
+  }
+
   const [head, tail] = Rng.$splitContainer(Dom.findLeaf, range);
   if (head) {
     Dom.$makeEditable(head);
@@ -115,7 +121,7 @@ export const stylePrevention: EditorMiddleware = (next, editor: MinidocBase) => 
     } else if (e.code === 'Backspace') {
       onBackspace(e);
     } else if (e.key === 'Enter') {
-      onEnter(e);
+      onEnter(e, editor);
     } else {
       // The user is typing, and we need to make sure we delete any
       // selection cleanly, or the editor will bork up the markup.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface MinidocBase {
   root: Element;
   readonly?: boolean;
+  singleLine?: boolean;
 }
 
 export interface MinidocOptions<T extends Array<EditorMiddleware | EditorMiddlewareMixin>> {
@@ -12,6 +13,10 @@ export interface MinidocOptions<T extends Array<EditorMiddleware | EditorMiddlew
    * Whether or not the document is editable or simply viewable.
    */
   readonly?: boolean;
+  /**
+   * If true, it prevents line breaks.
+   */
+  singleLine?: boolean;
   /**
    * If specified, this is the contenteditable used to render the document.
    */


### PR DESCRIPTION
I needed this prop to get the title working nice with minidoc.

![Screen Shot 2021-04-15 at 14 28 16](https://user-images.githubusercontent.com/2227041/114862770-99568800-9df7-11eb-9d28-771bba90e1d2.png)

Note: Ubuntu tests are somehow failing on a different test case.