### PR TITLE
Add type="button" to toolbar buttons.

### DIFF
--- a/src/toolbar/toolbar-button.ts
+++ b/src/toolbar/toolbar-button.ts
@@ -13,6 +13,7 @@ export function ToolbarButton(
     onclick() {
       run(editor);
     },
+    type: 'button',
     'aria-label': label,
     innerHTML: html,
   });


### PR DESCRIPTION
Toolbar buttons are triggering parent form's `onSubmit` event without setting the `type=button` explicitly.