### PR TITLE
Do not insert new line when cmd+enter is pressed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minidoc-editor",
-  "version": "0.0.36",
+  "version": "0.0.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "minidoc-editor",
-      "version": "0.0.36",
+      "version": "0.0.39",
       "license": "ISC",
       "devDependencies": {
         "@sinonjs/fake-timers": "7.1.2",

--- a/src/integration-test/minidoc-integration.test.ts
+++ b/src/integration-test/minidoc-integration.test.ts
@@ -588,6 +588,20 @@ function runTestsForBrowser(browserType: BrowserType) {
         );
       });
 
+      it('ctrl and enter', async () => {
+        await loadDoc(`<p>Hello world</p>`);
+        await selectRange('p', 11);
+
+        // Enter should insert a new line
+        await press('Enter');
+        const withNewLine = `<p>Hello world</p><p><br></p>`;
+        expect(await serializeDoc()).toEqual(withNewLine);
+
+        // Ctrl+Enter should not insert anything
+        await pressCtrl('Enter');
+        expect(await serializeDoc()).toEqual(withNewLine);
+      });
+
       it('select and type', async () => {
         const toolbarDoc = `<h1>Hello</h1><h2>There</h2><p><strong>I'm strong</strong><em>I'm emphasized</em></p><p>New P <b>I'm bold</b><i>I'm italic</i></p>`;
         await loadDoc(toolbarDoc);

--- a/src/style-prevention/style-prevention.ts
+++ b/src/style-prevention/style-prevention.ts
@@ -107,6 +107,11 @@ function onEnter(e: KeyboardEvent) {
 export const stylePrevention: EditorMiddleware = (next, editor: MinidocBase) => {
   const result = next(editor);
   Dom.on(result.root, 'keydown', (e) => {
+    // Do not insert a new line when pressing cmd+enter
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      return;
+    }
     if (e.defaultPrevented) {
       return;
     }


### PR DESCRIPTION
This prevents adding a new line when cmd+enter is pressed. `stylePrevention` looked like a good place to put this logic but let me know if you think this deserves a dedicated middleware.

Note: Can you publish a new version if you merge this?