### PR TITLE
Create h3 paragraphs when shift+enter is pressed.

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -338,8 +338,8 @@ export function h<T extends HTMLElement>(tag: string, ...args: any): T {
   return el as unknown as T;
 }
 
-export function newLeaf() {
-  return h('p', h('br'));
+export function newLeaf(element: 'p' | 'h3' = 'p') {
+  return h(element, h('br'));
 }
 
 /**

--- a/src/style-prevention/style-prevention.ts
+++ b/src/style-prevention/style-prevention.ts
@@ -99,7 +99,7 @@ function onEnter(e: KeyboardEvent) {
     Dom.$makeEditable(head);
   }
   if (tail) {
-    const leaf = Dom.isEmpty(tail) ? Dom.newLeaf() : tail;
+    const leaf = Dom.isEmpty(tail) ? Dom.newLeaf(e.shiftKey ? 'h3' : 'p') : tail;
     tail.replaceWith(leaf);
     Rng.setCaretAtStart(Dom.$makeEditable(leaf));
   }


### PR DESCRIPTION
This inserts a `h3` element instead of `p` when users press `shift+enter` keys.