### PR TITLE
Focus back to the editor when a toolbar button is clicked.

### DIFF
--- a/src/toolbar/toolbar-button.ts
+++ b/src/toolbar/toolbar-button.ts
@@ -5,13 +5,18 @@ export function ToolbarButton(
   editor: MinidocToolbarEditor,
   { label, isActive, html, run }: Pick<MinidocToolbarAction, 'label' | 'isActive' | 'html' | 'run'>,
 ) {
+  let lastActive: Element | null;
   const btn = h('button.minidoc-toolbar-btn', {
     refreshState:
       isActive &&
       ((editor: MinidocToolbarEditor) =>
         btn.classList.toggle('minidoc-toolbar-btn-active', isActive(editor))),
+    onmousedown: () => {
+      lastActive = document.activeElement;
+    },
     onclick() {
       run(editor);
+      (lastActive as HTMLElement)?.focus();
     },
     type: 'button',
     'aria-label': label,

--- a/src/toolbar/toolbar-button.ts
+++ b/src/toolbar/toolbar-button.ts
@@ -3,20 +3,16 @@ import { MinidocToolbarAction, MinidocToolbarEditor } from './toolbar-types';
 
 export function ToolbarButton(
   editor: MinidocToolbarEditor,
-  { label, isActive, html, run }: Pick<MinidocToolbarAction, 'label' | 'isActive' | 'html' | 'run'>,
+  { label, isActive, html, run, onMouseDown }: Pick<MinidocToolbarAction, 'label' | 'isActive' | 'html' | 'run' | 'onMouseDown'>,
 ) {
-  let lastActive: Element | null;
   const btn = h('button.minidoc-toolbar-btn', {
     refreshState:
       isActive &&
       ((editor: MinidocToolbarEditor) =>
         btn.classList.toggle('minidoc-toolbar-btn-active', isActive(editor))),
-    onmousedown: () => {
-      lastActive = document.activeElement;
-    },
+    onmousedown: onMouseDown,
     onclick() {
       run(editor);
-      (lastActive as HTMLElement)?.focus();
     },
     type: 'button',
     'aria-label': label,


### PR DESCRIPTION
This returns the focus back to the editor when a toolbar button is clicked. I think this improves the user experience and makes sure `document.getSelection` is returning the correct element.

Fixes https://github.com/morebetterlabs/ruzuku-v2/issues/3068.