### PR TITLE
Use classes to align items.

### DIFF
--- a/src/align/align-menu.ts
+++ b/src/align/align-menu.ts
@@ -27,10 +27,11 @@ export function align(direction: string, leafs?: Element[]) {
   if (!leafs) {
     return;
   }
-  const attr = 'data-align';
-  leafs.forEach((el) =>
-    direction === 'left' ? el.removeAttribute(attr) : el.setAttribute(attr, direction),
-  );
+  leafs.forEach((el) => {
+    el.classList.remove('text-right', 'text-center');
+    const className = direction === 'right' ? 'text-right' : direction === 'center' ? 'text-center' : '';
+    el.classList.add(className);
+  });
 }
 
 export function AlignMenu(editor: MinidocToolbarEditor) {

--- a/src/align/align-toolbar-actions.ts
+++ b/src/align/align-toolbar-actions.ts
@@ -6,7 +6,15 @@ import { AlignMenu, mkico } from './align-menu';
 function currentDirection() {
   const node = Rng.currentNode();
   const el = node && Dom.findLeaf(node);
-  return (el && el.getAttribute('data-align')) || 'left';
+  if (el) {
+    if (el.classList.contains('text-right')) {
+      return 'right';
+    }
+    if (el.classList.contains('text-center')) {
+      return 'center';
+    }
+  }
+  return 'left';
 }
 
 function toolbarIcon(direction: string) {

--- a/src/css/align.css
+++ b/src/css/align.css
@@ -1,7 +1,10 @@
-.minidoc-content [data-align=center] {
+/* keeping data-align for legacy support */
+.minidoc-content [data-align=center],
+.text-center {
   text-align: center;
 }
 
-.minidoc-content [data-align=right] {
+.minidoc-content [data-align=right],
+.text-right {
   text-align: right;
 }

--- a/src/scrubbable/scrubbable.ts
+++ b/src/scrubbable/scrubbable.ts
@@ -15,7 +15,7 @@ type Scrubber = (node: DocumentFragment, editor: MinidocBase) => DocumentFragmen
 
 const isSafeUrl = (s?: string) => !s?.startsWith('javascript:');
 
-export const leafRules = { 'data-align': true };
+export const leafRules = { 'class': true };
 
 export const rules: ScrubbableRules = {
   allowEmpty: ['HR'],


### PR DESCRIPTION
Eliminates `data-align` as that's not supported by email clients and using `class` to align elements.